### PR TITLE
Fix click % button crash when display value is 0

### DIFF
--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -50,6 +50,11 @@ export const reducer = (state, { type, value }) => {
           displayValue: String(newValue.toFixed(fixedDigits.length + 2)),
         }
       }
+
+      return {
+        ...state,
+        displayValue: String(currentValue),
+      }
     }
       break
     case 'toggleSign': {


### PR DESCRIPTION
From 
https://github.com/KaiHotz/React-Mac-Calculator/issues/1

`case 'inputPercent'` would not return a value if `currentValue` is 0.
So if I click the % button where`currentValue` is 0, the `state` value would be undefined.
This caused the crash.

So I add return value at last of the case block.